### PR TITLE
Use `exe` as RubyGems bindir

### DIFF
--- a/redactor2_rails.gemspec
+++ b/redactor2_rails.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = "bin"
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^#{spec.bindir}/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 


### PR DESCRIPTION
`redactor2_rails` currently provides RubyGems-global `console` and `setup` binaries, 
but it should not.